### PR TITLE
Change to fix with HHVM 3.6.0

### DIFF
--- a/zmq_common.h
+++ b/zmq_common.h
@@ -1,5 +1,4 @@
 #include "hphp/runtime/base/base-includes.h"
-#include "hphp/runtime/base/persistent-resource-store.h"
 #include "string.h"
 
 #include <zmq.h>
@@ -19,6 +18,7 @@ public:
   static void SetPersistent(int64_t io_threads, ContextData *context);
 
 private:
+  static std::string GetHash(const char *name, int64_t io_threads);
   static ContextData *GetCachedImpl(const char *name, int64_t io_threads);
   static void SetCachedImpl(const char *name, int64_t io_threads, ContextData *context);
 


### PR DESCRIPTION
NEWOBJ to newres
persistent-resource-store is gone, use thread_local map (found in https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/mysql/mysql_common.cpp)
<nitpick>Switch sockopts on numeric/strings.</nitpick>
<nitpick>ZMQ_\* are ints, not int64</nitpick>

I make no promises this works outside of "it worked for me"
fixes #4
